### PR TITLE
Update drawer.mdx

### DIFF
--- a/docs/pages/router/advanced/drawer.mdx
+++ b/docs/pages/router/advanced/drawer.mdx
@@ -16,6 +16,12 @@ To use [drawer navigator](https://reactnavigation.org/docs/drawer-based-navigati
   ]}
 />
 
+<Terminal
+  cmd={[
+    '$ npm install -D @babel/plugin-transform-export-namespace-from',
+  ]}
+/>
+
 Next, you'll need to update your **babel.config.js** to include the reanimated plugin:
 
 {/* prettier-ignore */}
@@ -27,6 +33,7 @@ module.exports = {
     plugins: [
       /* @hide ... */ /* @end */
       'react-native-reanimated/plugin',
+'@babel/plugin-transform-export-namespace-from'
     ],
 };
 ```


### PR DESCRIPTION
for drawer work without errors

# Why

<!--
without adding "@babel/plugin-transform-export-namespace-from" to babel config the app will not build on web, it will build only on emulator
-->

# How

<!--
Feature mentioned in react-native-reanimated docs in expo documentation, while trying to build for web using this documentation I was having log errors from react-native-reanimated@2 and build was not completed
-->

# Test Plan

<!--
I have tested on my machine and on test production using vercel
-->

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [* ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ *] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [* ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
